### PR TITLE
Delay color cycler activation until visible cards exist

### DIFF
--- a/New York Times/NYT Connections Color Cycler-1.0.user.js
+++ b/New York Times/NYT Connections Color Cycler-1.0.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         NYT Connections Color Cycler
 // @namespace    https://github.com/brucehart/userscripts
-// @version      1.9
+// @version      1.10
 // @description  Cycle Connections words through native selected and hint colors, with bulk color action buttons.
 // @author       Bruce J. Hart
 // @match        https://www.nytimes.com/games/connections*
@@ -31,17 +31,87 @@
 
   let reapplyQueued = false;
   let toolbarDeselecting = false; // true while applyColorToSelectedCards deselects cards
+  let gameHooksAttached = false;
+  let gameObserver = null;
+  let bootstrapObserver = null;
 
   injectStyles();
-  queueReapply();
-  window.addEventListener('pointerdown', onPointerDown, true);
-  window.addEventListener('click', onCardClick, true);
+  activateWhenReady();
 
-  const observer = new MutationObserver(() => {
-    reapplyAllStates();  // Synchronously reapply colors immediately on DOM change
-    queueReapply();      // Also queue the full reapply (which includes ensureToolbar)
-  });
-  observer.observe(document.documentElement, { childList: true, subtree: true, attributes: true, attributeFilter: ['class', 'aria-pressed', 'aria-selected', 'aria-checked', 'data-state', 'aria-disabled', 'data-testid'] });
+  function activateWhenReady() {
+    if (hasGameCards()) {
+      attachGameHooks();
+      stopBootstrapObserver();
+      queueReapply();
+      return;
+    }
+
+    removeToolbar();
+    startBootstrapObserver();
+  }
+
+  function attachGameHooks() {
+    if (!gameHooksAttached) {
+      window.addEventListener('pointerdown', onPointerDown, true);
+      window.addEventListener('click', onCardClick, true);
+      gameHooksAttached = true;
+    }
+
+    if (gameObserver) {
+      return;
+    }
+
+    gameObserver = new MutationObserver(() => {
+      if (!hasGameCards()) {
+        stopGameObserver();
+        removeToolbar();
+        startBootstrapObserver();
+        return;
+      }
+
+      queueReapply();
+    });
+    gameObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  function startBootstrapObserver() {
+    if (bootstrapObserver || hasGameCards()) {
+      return;
+    }
+
+    bootstrapObserver = new MutationObserver(() => {
+      if (hasGameCards()) {
+        attachGameHooks();
+        stopBootstrapObserver();
+        queueReapply();
+      }
+    });
+    bootstrapObserver.observe(document.documentElement, {
+      childList: true,
+      subtree: true
+    });
+  }
+
+  function stopBootstrapObserver() {
+    if (!bootstrapObserver) {
+      return;
+    }
+
+    bootstrapObserver.disconnect();
+    bootstrapObserver = null;
+  }
+
+  function stopGameObserver() {
+    if (!gameObserver) {
+      return;
+    }
+
+    gameObserver.disconnect();
+    gameObserver = null;
+  }
 
   function onPointerDown(event) {
     if (!event.isTrusted) {
@@ -254,6 +324,10 @@
 
     requestAnimationFrame(() => {
       reapplyQueued = false;
+      if (!hasGameCards()) {
+        removeToolbar();
+        return;
+      }
       ensureToolbar();
       reapplyAllStates();
     });
@@ -323,6 +397,11 @@
       return;
     }
 
+    if (!hasGameCards()) {
+      removeToolbar();
+      return;
+    }
+
     const mountPoint = findToolbarMountPoint();
     let toolbar = document.getElementById(TOOLBAR_ID);
 
@@ -341,6 +420,32 @@
     toolbar.setAttribute(TOOLBAR_FLOAT_ATTR, 'true');
     if (toolbar.parentElement !== document.body) {
       document.body.appendChild(toolbar);
+    }
+  }
+
+  function hasGameCards() {
+    const cards = document.querySelectorAll(CARD_SELECTOR);
+    for (const card of cards) {
+      if (isCardVisible(card)) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  function isCardVisible(card) {
+    if (!(card instanceof Element)) {
+      return false;
+    }
+
+    return card.getClientRects().length > 0;
+  }
+
+  function removeToolbar() {
+    const toolbar = document.getElementById(TOOLBAR_ID);
+    if (toolbar) {
+      toolbar.remove();
     }
   }
 
@@ -539,6 +644,10 @@
         position: fixed;
         right: 16px;
         bottom: 16px;
+        left: auto;
+        width: auto;
+        min-width: 0;
+        max-width: calc(100vw - 32px);
         margin-top: 0;
         padding: 10px;
         border-radius: 16px;


### PR DESCRIPTION
## Summary
- Fix the NYT Connections color cycler startup regression introduced by the v1.9 reapply timing change.
- Keep the userscript dormant until visible game cards exist so the pre-start page stays responsive.

## Changes
- Replace the eager full-page mutation observer with a two-phase startup flow: a lightweight bootstrap observer before the board exists and the normal game observer after visible cards appear.
- Remove the broad attribute observer and synchronous reapply path that were added in v1.9.
- Prevent the floating toolbar fallback from using full-width fixed sizing before the board is ready.
- Bump the userscript version from `1.9` to `1.10`.

## Testing
- Ran `node --check "New York Times/NYT Connections Color Cycler-1.0.user.js"`.
- Validated manually against the same startup hang reproduced from commit `2091cefec6f6b41086f750704aa203043e781c8f`.

## Notes
- This preserves the color-cycling and toolbar behavior after the board loads while avoiding the pre-game hang.
