### PR TITLE
Add Instagram video audio muxing

### DIFF
--- a/Instagram/Instagram View Image in New Tab-1.0.user.js
+++ b/Instagram/Instagram View Image in New Tab-1.0.user.js
@@ -1,12 +1,13 @@
 // ==UserScript==
 // @name         Instagram View Image in New Tab
 // @namespace    https://github.com/brucehart/userscripts
-// @version      1.5
+// @version      1.6
 // @description  Add right-click menu items on Instagram images and videos to open, save, or copy the real media.
 // @author       Bruce J. Hart
 // @match        https://www.instagram.com/*
 // @match        https://instagram.com/*
 // @run-at       document-idle
+// @require      https://unpkg.com/@ffmpeg/ffmpeg@0.11.6/dist/ffmpeg.min.js
 // @grant        GM_openInTab
 // @grant        GM_download
 // @grant        GM_setClipboard
@@ -19,14 +20,21 @@
   'use strict';
 
   const MENU_ID = 'tm-instagram-view-image-menu';
+  const STATUS_ID = 'tm-instagram-view-image-status';
   const MAX_ANCESTOR_DEPTH = 8;
   const INSTAGRAM_MEDIA_PATH_PATTERN = /^\/(?:p|reel|reels|tv)\/[^/?#]+\/?/i;
   const INSTAGRAM_MEDIA_LINK_SELECTOR = 'a[href^="/p/"], a[href^="/reel/"], a[href^="/reels/"], a[href^="/tv/"]';
-  const VIDEO_URL_KEY_PATTERN = /^(?:video_url|playable_url|playable_url_quality_hd|dash_manifest|contentUrl|src|url)$/i;
+  const DASH_MANIFEST_KEY_PATTERN = /dash_manifest/i;
+  const VIDEO_URL_KEY_PATTERN = /^(?:video_url|playable_url|playable_url_quality_hd|dash_manifest|video_dash_manifest|contentUrl|src|url)$/i;
   const MAX_OBJECT_SEARCH_DEPTH = 8;
   const MAX_OBJECT_SEARCH_NODES = 2500;
+  const FFMPEG_CORE_URL = 'https://unpkg.com/@ffmpeg/core@0.11.0/dist/ffmpeg-core.js';
   let activeMedia = null;
   let menu = null;
+  let statusBox = null;
+  let ffmpegInstance = null;
+  let ffmpegLoadPromise = null;
+  let muxQueue = Promise.resolve();
 
   function normalizeUrl(rawUrl) {
     if (!rawUrl) return '';
@@ -102,6 +110,114 @@
     } catch (e) {
       return false;
     }
+  }
+
+  function createVideoDetails(videoUrl, audioUrl) {
+    return {
+      videoUrl: videoUrl || '',
+      audioUrl: audioUrl || ''
+    };
+  }
+
+  function hasVideoDetails(details) {
+    return Boolean(details && details.videoUrl);
+  }
+
+  function hasSeparateAudio(details) {
+    return Boolean(details && details.videoUrl && details.audioUrl && details.videoUrl !== details.audioUrl);
+  }
+
+  function videoDetailsFromUrl(url) {
+    return createVideoDetails(url, '');
+  }
+
+  function keySearchPriority(key) {
+    if (DASH_MANIFEST_KEY_PATTERN.test(key)) return 0;
+    if (/^(?:video_url|playable_url_quality_hd|playable_url|contentUrl)$/i.test(key)) return 1;
+    if (/^(?:src|url)$/i.test(key)) return 2;
+    return 3;
+  }
+
+  function numericAttribute(element, names) {
+    for (const name of names) {
+      const value = parseFloat(element.getAttribute(name) || '');
+      if (Number.isFinite(value)) return value;
+    }
+
+    return 0;
+  }
+
+  function childElementsByName(element, localName) {
+    const normalizedName = localName.toLowerCase();
+    return [...element.children].filter(function (child) {
+      return child.localName && child.localName.toLowerCase() === normalizedName;
+    });
+  }
+
+  function firstChildTextByName(element, localName) {
+    const child = childElementsByName(element, localName)[0];
+    return child ? child.textContent || '' : '';
+  }
+
+  function dashAdaptationType(adaptationSet, representation) {
+    const combinedAttributes = [
+      adaptationSet.getAttribute('contentType'),
+      adaptationSet.getAttribute('mimeType'),
+      adaptationSet.getAttribute('codecs'),
+      representation && representation.getAttribute('mimeType'),
+      representation && representation.getAttribute('codecs')
+    ].filter(Boolean).join(' ').toLowerCase();
+
+    if (/audio|mp4a|opus|vorbis/.test(combinedAttributes)) return 'audio';
+    if (/video|avc|hev|hvc|vp9|h26[45]/.test(combinedAttributes)) return 'video';
+    return '';
+  }
+
+  function dashRepresentationScore(adaptationSet, representation, type) {
+    const bandwidth = numericAttribute(representation, ['bandwidth'])
+      || numericAttribute(adaptationSet, ['bandwidth']);
+
+    if (type === 'audio') return bandwidth;
+
+    const width = numericAttribute(representation, ['width']) || numericAttribute(adaptationSet, ['width']);
+    const height = numericAttribute(representation, ['height']) || numericAttribute(adaptationSet, ['height']);
+    return (height * 100000000) + (width * 100000) + bandwidth;
+  }
+
+  function bestDashBaseUrlsFromDocument(doc) {
+    const parserError = doc.querySelector('parsererror');
+    if (parserError) return createVideoDetails('', '');
+
+    const best = {
+      video: { url: '', score: -1 },
+      audio: { url: '', score: -1 }
+    };
+    const adaptationSets = [...doc.getElementsByTagName('*')].filter(function (element) {
+      return element.localName && element.localName.toLowerCase() === 'adaptationset';
+    });
+
+    for (const adaptationSet of adaptationSets) {
+      let representations = childElementsByName(adaptationSet, 'Representation');
+      if (!representations.length) representations = [adaptationSet];
+
+      for (const representation of representations) {
+        const type = dashAdaptationType(adaptationSet, representation);
+        if (type !== 'video' && type !== 'audio') continue;
+
+        const baseUrl = normalizeAbsoluteUrl(
+          firstChildTextByName(representation, 'BaseURL')
+          || firstChildTextByName(adaptationSet, 'BaseURL')
+        );
+        if (!baseUrl) continue;
+
+        const score = dashRepresentationScore(adaptationSet, representation, type);
+        if (score > best[type].score) {
+          best[type] = { url: baseUrl, score };
+        }
+      }
+    }
+
+    return createVideoDetails(best.video.url, best.audio.url);
   }
 
   function currentInstagramMediaPageUrl() {
@@ -288,16 +404,36 @@
     return expandedValues;
   }
 
-  function videoUrlFromDashManifest(rawValue) {
+  function videoDetailsFromDashManifest(rawValue) {
     for (const candidate of expandPossibleVideoStrings(rawValue)) {
-      const baseUrlMatch = candidate.match(/<BaseURL>([\s\S]*?)<\/BaseURL>/i);
+      const manifestText = decodeHtmlEntities(candidate);
+      if (!/<BaseURL\b/i.test(manifestText)) continue;
+
+      const doc = new DOMParser().parseFromString(manifestText, 'application/xml');
+      const details = bestDashBaseUrlsFromDocument(doc);
+      if (hasVideoDetails(details)) return details;
+
+      const baseUrlMatch = manifestText.match(/<BaseURL[^>]*>([\s\S]*?)<\/BaseURL>/i);
       if (!baseUrlMatch) continue;
 
       const url = normalizeAbsoluteUrl(baseUrlMatch[1]);
-      if (isLikelyVideoUrl(url)) return url;
+      if (isLikelyVideoUrl(url)) return videoDetailsFromUrl(url);
     }
 
-    return '';
+    return createVideoDetails('', '');
+  }
+
+  function videoUrlFromDashManifest(rawValue) {
+    return videoDetailsFromDashManifest(rawValue).videoUrl;
+  }
+
+  function normalizePotentialVideoDetails(rawValue) {
+    if (typeof rawValue !== 'string') return createVideoDetails('', '');
+
+    const manifestDetails = videoDetailsFromDashManifest(rawValue);
+    if (hasVideoDetails(manifestDetails)) return manifestDetails;
+
+    return videoDetailsFromUrl(normalizePotentialVideoUrl(rawValue));
   }
 
   function normalizePotentialVideoUrl(rawValue) {
@@ -320,33 +456,32 @@
     return '';
   }
 
-  function findVideoUrlInValue(value, state, depth) {
-    if (!value || state.nodes > MAX_OBJECT_SEARCH_NODES || depth > MAX_OBJECT_SEARCH_DEPTH) return '';
+  function findVideoDetailsInValue(value, state, depth) {
+    if (!value || state.nodes > MAX_OBJECT_SEARCH_NODES || depth > MAX_OBJECT_SEARCH_DEPTH) {
+      return createVideoDetails('', '');
+    }
     state.nodes += 1;
 
-    if (typeof value === 'string') return normalizePotentialVideoUrl(value);
-    if (typeof value !== 'object' && typeof value !== 'function') return '';
-    if (state.visited.has(value)) return '';
+    if (typeof value === 'string') return normalizePotentialVideoDetails(value);
+    if (typeof value !== 'object' && typeof value !== 'function') return createVideoDetails('', '');
+    if (state.visited.has(value)) return createVideoDetails('', '');
 
     state.visited.add(value);
 
     if (Array.isArray(value)) {
       for (const item of value) {
-        const url = findVideoUrlInValue(item, state, depth + 1);
-        if (url) return url;
+        const details = findVideoDetailsInValue(item, state, depth + 1);
+        if (hasVideoDetails(details)) return details;
       }
-      return '';
+      return createVideoDetails('', '');
     }
 
-    const keys = Object.keys(value);
-    const priorityKeys = keys.filter(function (key) {
-      return VIDEO_URL_KEY_PATTERN.test(key);
-    });
-    const remainingKeys = keys.filter(function (key) {
-      return !VIDEO_URL_KEY_PATTERN.test(key);
+    const keys = Object.keys(value).sort(function (left, right) {
+      const priorityDelta = keySearchPriority(left) - keySearchPriority(right);
+      return priorityDelta || 0;
     });
 
-    for (const key of priorityKeys.concat(remainingKeys)) {
+    for (const key of keys) {
       let nestedValue;
       try {
         nestedValue = value[key];
@@ -354,14 +489,22 @@
         continue;
       }
 
-      const url = findVideoUrlInValue(nestedValue, state, depth + 1);
-      if (url) return url;
+      if (
+        keySearchPriority(key) > 2
+        && !VIDEO_URL_KEY_PATTERN.test(key)
+        && (nestedValue === null || (typeof nestedValue !== 'object' && typeof nestedValue !== 'function'))
+      ) {
+        continue;
+      }
+
+      const details = findVideoDetailsInValue(nestedValue, state, depth + 1);
+      if (hasVideoDetails(details)) return details;
     }
 
-    return '';
+    return createVideoDetails('', '');
   }
 
-  function findVideoUrlInElementData(element) {
+  function findVideoDetailsInElementData(element) {
     const state = {
       visited: new WeakSet(),
       nodes: 0
@@ -377,14 +520,14 @@
         continue;
       }
 
-      const url = findVideoUrlInValue(value, state, 0);
-      if (url) return url;
+      const details = findVideoDetailsInValue(value, state, 0);
+      if (hasVideoDetails(details)) return details;
     }
 
-    return '';
+    return createVideoDetails('', '');
   }
 
-  function videoUrlFromAttachedPageData(startElement) {
+  function videoDetailsFromAttachedPageData(startElement) {
     const elements = [];
     let element = startElement;
     let depth = 0;
@@ -396,26 +539,28 @@
     }
 
     for (const candidate of elements) {
-      const url = findVideoUrlInElementData(candidate);
-      if (url) return url;
+      const details = findVideoDetailsInElementData(candidate);
+      if (hasVideoDetails(details)) return details;
     }
 
-    return '';
+    return createVideoDetails('', '');
   }
 
-  function videoUrlFromPerformanceEntries() {
-    if (!window.performance || typeof window.performance.getEntriesByType !== 'function') return '';
+  function videoDetailsFromPerformanceEntries() {
+    if (!window.performance || typeof window.performance.getEntriesByType !== 'function') {
+      return createVideoDetails('', '');
+    }
 
     const entries = window.performance.getEntriesByType('resource').slice().reverse();
     for (const entry of entries) {
       const url = normalizePotentialVideoUrl(entry.name);
-      if (url) return url;
+      if (url) return videoDetailsFromUrl(url);
     }
 
-    return '';
+    return createVideoDetails('', '');
   }
 
-  function videoUrlFromPageGlobals() {
+  function videoDetailsFromPageGlobals() {
     const pageWindow = typeof unsafeWindow === 'undefined' ? window : unsafeWindow;
     const globalNames = [
       '_sharedData',
@@ -437,36 +582,28 @@
         continue;
       }
 
-      const url = findVideoUrlInValue(value, state, 0);
-      if (url) return url;
+      const details = findVideoDetailsInValue(value, state, 0);
+      if (hasVideoDetails(details)) return details;
     }
 
-    return '';
+    return createVideoDetails('', '');
   }
 
-  function videoUrlFromDocumentScripts() {
+  function videoDetailsFromDocumentScripts() {
     const scripts = [...document.scripts].slice().reverse();
     for (const script of scripts) {
-      const url = extractVideoUrlFromHtml(script.textContent || '');
-      if (url) return url;
+      const details = extractVideoDetailsFromHtml(script.textContent || '');
+      if (hasVideoDetails(details)) return details;
     }
 
-    return '';
+    return createVideoDetails('', '');
   }
 
-  function extractVideoUrlFromHtml(html) {
+  function extractVideoDetailsFromHtml(html) {
     const decodedHtml = decodeHtmlEntities(html);
-    const doc = new DOMParser().parseFromString(decodedHtml, 'text/html');
-    const metaVideo = doc.querySelector([
-      'meta[property="og:video"]',
-      'meta[property="og:video:url"]',
-      'meta[property="og:video:secure_url"]',
-      'meta[name="twitter:player:stream"]'
-    ].join(','));
-    const metaUrl = metaVideo ? normalizePotentialVideoUrl(metaVideo.getAttribute('content')) : '';
-    if (metaUrl) return metaUrl;
-
     const patterns = [
+      /"dash_manifest"\s*:\s*"((?:\\.|[^"\\])+)"/,
+      /"video_dash_manifest"\s*:\s*"((?:\\.|[^"\\])+)"/,
       /"video_url"\s*:\s*"((?:\\.|[^"\\])+)"/,
       /"playable_url_quality_hd"\s*:\s*"((?:\\.|[^"\\])+)"/,
       /"playable_url"\s*:\s*"((?:\\.|[^"\\])+)"/,
@@ -477,11 +614,21 @@
       const match = decodedHtml.match(pattern);
       if (!match) continue;
 
-      const url = normalizePotentialVideoUrl(decodeJsonString(match[1]));
-      if (url) return url;
+      const details = normalizePotentialVideoDetails(decodeJsonString(match[1]));
+      if (hasVideoDetails(details)) return details;
     }
 
-    return '';
+    const doc = new DOMParser().parseFromString(decodedHtml, 'text/html');
+    const metaVideo = doc.querySelector([
+      'meta[property="og:video"]',
+      'meta[property="og:video:url"]',
+      'meta[property="og:video:secure_url"]',
+      'meta[name="twitter:player:stream"]'
+    ].join(','));
+    const metaUrl = metaVideo ? normalizePotentialVideoUrl(metaVideo.getAttribute('content')) : '';
+    if (metaUrl) return videoDetailsFromUrl(metaUrl);
+
+    return createVideoDetails('', '');
   }
 
   function getText(url) {
@@ -511,55 +658,107 @@
     });
   }
 
-  function resolveVideoMediaUrl(media) {
-    if (media.url && isLikelyVideoUrl(media.url)) return Promise.resolve(media.url);
+  function applyVideoDetailsToMedia(media, details) {
+    if (!media || !hasVideoDetails(details)) return media;
+
+    media.videoUrl = details.videoUrl;
+    media.audioUrl = details.audioUrl || '';
+    media.url = details.videoUrl;
+    media.needsMuxing = hasSeparateAudio(details);
+    media.filename = filenameFromMediaUrl(details.videoUrl, media.type);
+    return media;
+  }
+
+  function directVideoDetailsFromMedia(media) {
+    const url = normalizePotentialVideoUrl(media && (media.videoUrl || media.url));
+    return url ? videoDetailsFromUrl(url) : createVideoDetails('', '');
+  }
+
+  function resolveVideoMedia(media) {
+    if (!media) return Promise.resolve(null);
+    if (media.needsMuxing && media.videoUrl && media.audioUrl) return Promise.resolve(media);
+
+    let fallbackDetails = createVideoDetails('', '');
+    function rememberFallback(details) {
+      if (hasVideoDetails(details) && !hasVideoDetails(fallbackDetails)) {
+        fallbackDetails = details;
+      }
+      return hasSeparateAudio(details);
+    }
+
     if (media.videoElement) {
-      const attachedUrl = videoUrlFromAttachedPageData(media.videoElement);
-      if (attachedUrl) {
-        media.url = attachedUrl;
-        media.filename = filenameFromMediaUrl(attachedUrl, media.type);
-        return Promise.resolve(attachedUrl);
+      const attachedDetails = videoDetailsFromAttachedPageData(media.videoElement);
+      if (rememberFallback(attachedDetails)) {
+        return Promise.resolve(applyVideoDetailsToMedia(media, attachedDetails));
       }
     }
 
-    const performanceUrl = videoUrlFromPerformanceEntries();
-    if (performanceUrl) {
-      media.url = performanceUrl;
-      media.filename = filenameFromMediaUrl(performanceUrl, media.type);
-      return Promise.resolve(performanceUrl);
+    const globalDetails = videoDetailsFromPageGlobals();
+    if (rememberFallback(globalDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, globalDetails));
     }
 
-    const globalUrl = videoUrlFromPageGlobals();
-    if (globalUrl) {
-      media.url = globalUrl;
-      media.filename = filenameFromMediaUrl(globalUrl, media.type);
-      return Promise.resolve(globalUrl);
+    const scriptDetails = videoDetailsFromDocumentScripts();
+    if (rememberFallback(scriptDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, scriptDetails));
     }
 
-    const scriptUrl = videoUrlFromDocumentScripts();
-    if (scriptUrl) {
-      media.url = scriptUrl;
-      media.filename = filenameFromMediaUrl(scriptUrl, media.type);
-      return Promise.resolve(scriptUrl);
+    if (media.pageUrl) {
+      if (media.resolvedMediaPromise) return media.resolvedMediaPromise;
+
+      media.resolvedMediaPromise = getText(media.pageUrl)
+        .then(extractVideoDetailsFromHtml)
+        .then(function (details) {
+          if (hasVideoDetails(details)) return applyVideoDetailsToMedia(media, details);
+
+          if (hasVideoDetails(fallbackDetails)) return applyVideoDetailsToMedia(media, fallbackDetails);
+
+          const directDetails = directVideoDetailsFromMedia(media);
+          if (hasVideoDetails(directDetails)) return applyVideoDetailsToMedia(media, directDetails);
+
+          const performanceDetails = videoDetailsFromPerformanceEntries();
+          if (hasVideoDetails(performanceDetails)) return applyVideoDetailsToMedia(media, performanceDetails);
+
+          return media;
+        })
+        .catch(function (error) {
+          console.warn('Instagram View Image in New Tab: could not resolve video URL.', error);
+
+          if (hasVideoDetails(fallbackDetails)) return applyVideoDetailsToMedia(media, fallbackDetails);
+
+          const directDetails = directVideoDetailsFromMedia(media);
+          if (hasVideoDetails(directDetails)) return applyVideoDetailsToMedia(media, directDetails);
+
+          const performanceDetails = videoDetailsFromPerformanceEntries();
+          if (hasVideoDetails(performanceDetails)) return applyVideoDetailsToMedia(media, performanceDetails);
+
+          return media;
+        });
+
+      return media.resolvedMediaPromise;
     }
 
-    if (!media.pageUrl) return Promise.resolve('');
+    if (hasVideoDetails(fallbackDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, fallbackDetails));
+    }
 
-    if (media.resolvedUrlPromise) return media.resolvedUrlPromise;
+    const directDetails = directVideoDetailsFromMedia(media);
+    if (hasVideoDetails(directDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, directDetails));
+    }
 
-    media.resolvedUrlPromise = getText(media.pageUrl)
-      .then(extractVideoUrlFromHtml)
-      .then(function (videoUrl) {
-        media.url = videoUrl;
-        media.filename = filenameFromMediaUrl(videoUrl, media.type);
-        return videoUrl;
-      })
-      .catch(function (error) {
-        console.warn('Instagram View Image in New Tab: could not resolve video URL.', error);
-        return '';
-      });
+    const performanceDetails = videoDetailsFromPerformanceEntries();
+    if (hasVideoDetails(performanceDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, performanceDetails));
+    }
 
-    return media.resolvedUrlPromise;
+    return Promise.resolve(media);
+  }
+
+  function resolveVideoMediaUrl(media) {
+    return resolveVideoMedia(media).then(function (resolvedMedia) {
+      return resolvedMedia ? resolvedMedia.videoUrl || resolvedMedia.url || '' : '';
+    });
   }
 
   function resolveActiveMediaUrl(media) {
@@ -587,6 +786,8 @@
     const pageUrl = instagramMediaPageUrlFromElement(video);
     return {
       url: videoUrl,
+      videoUrl,
+      audioUrl: '',
       type: 'video',
       pageUrl,
       videoElement: video
@@ -721,9 +922,12 @@
   function showMenu(x, y, media) {
     activeMedia = {
       url: media.url,
+      videoUrl: media.videoUrl || media.url,
+      audioUrl: media.audioUrl || '',
       type: media.type,
       pageUrl: media.pageUrl || '',
       videoElement: media.videoElement || null,
+      needsMuxing: hasSeparateAudio(media),
       filename: filenameFromMediaUrl(media.url, media.type)
     };
 
@@ -744,6 +948,241 @@
     if (menu) menu.style.display = 'none';
   }
 
+  function ensureStatusBox() {
+    if (statusBox) return statusBox;
+
+    statusBox = document.createElement('div');
+    statusBox.id = STATUS_ID;
+    statusBox.innerHTML = `
+      <div data-role="message"></div>
+      <div data-role="detail"></div>
+    `;
+    document.body.appendChild(statusBox);
+
+    const style = document.createElement('style');
+    style.textContent = `
+      #${STATUS_ID} {
+        position: fixed;
+        right: 16px;
+        bottom: 16px;
+        z-index: 2147483647;
+        display: none;
+        max-width: min(360px, calc(100vw - 32px));
+        padding: 10px 12px;
+        background: #111;
+        border-radius: 8px;
+        box-shadow: 0 8px 24px rgba(0, 0, 0, 0.28);
+        color: #fff;
+        font: 13px/1.4 -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+      }
+
+      #${STATUS_ID} [data-role="message"] {
+        font-weight: 600;
+      }
+
+      #${STATUS_ID} [data-role="detail"] {
+        margin-top: 2px;
+        color: rgba(255, 255, 255, 0.72);
+      }
+    `;
+    document.head.appendChild(style);
+
+    return statusBox;
+  }
+
+  function showStatus(message, detail) {
+    const box = ensureStatusBox();
+    box.querySelector('[data-role="message"]').textContent = message || '';
+    box.querySelector('[data-role="detail"]').textContent = detail || '';
+    box.style.display = 'block';
+  }
+
+  function hideStatus() {
+    if (statusBox) statusBox.style.display = 'none';
+  }
+
+  function formatPercent(value) {
+    if (!Number.isFinite(value) || value <= 0) return '';
+    return `${Math.min(100, Math.max(0, Math.round(value * 100)))}%`;
+  }
+
+  function progressDetail(event) {
+    if (!event || !event.lengthComputable || !event.total) return '';
+    return formatPercent(event.loaded / event.total);
+  }
+
+  function openUrlInTab(url) {
+    if (typeof GM_openInTab === 'function') {
+      GM_openInTab(url, { active: true, insert: true });
+    } else {
+      window.open(url, '_blank', 'noopener');
+    }
+  }
+
+  function saveBlob(blob, filename) {
+    const objectUrl = URL.createObjectURL(blob);
+    const link = document.createElement('a');
+    link.href = objectUrl;
+    link.download = filename;
+    link.rel = 'noopener';
+    document.body.appendChild(link);
+    link.click();
+    link.remove();
+    window.setTimeout(function () {
+      URL.revokeObjectURL(objectUrl);
+    }, 30000);
+  }
+
+  function getFfmpegLibrary() {
+    const pageWindow = typeof unsafeWindow === 'undefined' ? window : unsafeWindow;
+    return globalThis.FFmpeg || window.FFmpeg || pageWindow.FFmpeg || null;
+  }
+
+  function ensureFfmpeg() {
+    const ffmpegLibrary = getFfmpegLibrary();
+    if (!ffmpegLibrary || typeof ffmpegLibrary.createFFmpeg !== 'function') {
+      return Promise.reject(new Error('ffmpeg.wasm did not load'));
+    }
+
+    if (!ffmpegInstance) {
+      ffmpegInstance = ffmpegLibrary.createFFmpeg({
+        log: false,
+        corePath: FFMPEG_CORE_URL,
+        progress: function (progress) {
+          const percent = progress && Number.isFinite(progress.ratio) ? formatPercent(progress.ratio) : '';
+          showStatus('Merging video and audio...', percent);
+        }
+      });
+    }
+
+    if (ffmpegInstance.isLoaded()) return Promise.resolve(ffmpegInstance);
+    if (ffmpegLoadPromise) return ffmpegLoadPromise;
+
+    showStatus('Loading video merger...', 'This can take a moment the first time.');
+    ffmpegLoadPromise = ffmpegInstance.load()
+      .then(function () {
+        return ffmpegInstance;
+      })
+      .catch(function (error) {
+        ffmpegLoadPromise = null;
+        throw error;
+      });
+
+    return ffmpegLoadPromise;
+  }
+
+  function getBinary(url, label) {
+    if (typeof GM_xmlhttpRequest === 'function') {
+      return new Promise(function (resolve, reject) {
+        GM_xmlhttpRequest({
+          method: 'GET',
+          url,
+          responseType: 'arraybuffer',
+          onprogress: function (event) {
+            showStatus(`Downloading ${label}...`, progressDetail(event));
+          },
+          onload: function (response) {
+            if (response.status >= 200 && response.status < 300 && response.response) {
+              resolve(new Uint8Array(response.response));
+            } else {
+              reject(new Error(`${label} request failed with status ${response.status}`));
+            }
+          },
+          onerror: function () {
+            reject(new Error(`${label} request failed`));
+          }
+        });
+      });
+    }
+
+    showStatus(`Downloading ${label}...`, '');
+    return fetch(url, { credentials: 'omit' }).then(function (response) {
+      if (!response.ok) throw new Error(`${label} request failed with status ${response.status}`);
+      return response.arrayBuffer();
+    }).then(function (buffer) {
+      return new Uint8Array(buffer);
+    });
+  }
+
+  function removeFfmpegFile(ffmpeg, filename) {
+    try {
+      ffmpeg.FS('unlink', filename);
+    } catch (e) {
+      // Missing cleanup files are harmless.
+    }
+  }
+
+  function muxVideoMediaNow(media) {
+    if (!media || !media.videoUrl || !media.audioUrl) {
+      return Promise.reject(new Error('Missing separate video or audio stream'));
+    }
+
+    const id = `${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
+    const videoInput = `instagram-video-${id}.mp4`;
+    const audioInput = `instagram-audio-${id}.m4a`;
+    const output = `instagram-merged-${id}.mp4`;
+    let ffmpegForCleanup = null;
+
+    return ensureFfmpeg()
+      .then(function (ffmpeg) {
+        ffmpegForCleanup = ffmpeg;
+        return getBinary(media.videoUrl, 'video stream')
+          .then(function (videoBytes) {
+            return getBinary(media.audioUrl, 'audio stream').then(function (audioBytes) {
+              return { ffmpeg, videoBytes, audioBytes };
+            });
+          });
+      })
+      .then(function (payload) {
+        const ffmpeg = payload.ffmpeg;
+        showStatus('Preparing video and audio...', '');
+        ffmpeg.FS('writeFile', videoInput, payload.videoBytes);
+        ffmpeg.FS('writeFile', audioInput, payload.audioBytes);
+        showStatus('Merging video and audio...', '');
+
+        return ffmpeg.run(
+          '-i', videoInput,
+          '-i', audioInput,
+          '-map', '0:v:0',
+          '-map', '1:a:0',
+          '-c', 'copy',
+          '-shortest',
+          '-movflags', '+faststart',
+          output
+        ).then(function () {
+          const mergedBytes = ffmpeg.FS('readFile', output);
+          return new Blob([mergedBytes], { type: 'video/mp4' });
+        });
+      })
+      .finally(function () {
+        if (!ffmpegForCleanup) return;
+        removeFfmpegFile(ffmpegForCleanup, videoInput);
+        removeFfmpegFile(ffmpegForCleanup, audioInput);
+        removeFfmpegFile(ffmpegForCleanup, output);
+      });
+  }
+
+  function muxVideoMedia(media) {
+    const run = muxQueue.catch(function () {}).then(function () {
+      return muxVideoMediaNow(media);
+    });
+    muxQueue = run.catch(function () {});
+    return run;
+  }
+
+  function handleMuxFailure(error, media) {
+    console.warn('Instagram View Image in New Tab: could not merge video and audio.', error);
+    hideStatus();
+
+    if (media && media.videoUrl) {
+      window.alert('Found separate Instagram video and audio streams, but could not merge them in this browser. Falling back to the video-only stream.');
+      return media.videoUrl;
+    }
+
+    window.alert('Found separate Instagram video and audio streams, but could not merge them in this browser.');
+    return '';
+  }
+
   function handleMenuClick(event) {
     const button = event.target.closest('button[data-action]');
     if (!button) return;
@@ -761,17 +1200,42 @@
     const media = activeMedia;
     hideMenu();
 
-    resolveActiveMediaUrl(media).then(function (mediaUrl) {
+    if (!media || media.type !== 'video') {
+      resolveActiveMediaUrl(media).then(function (mediaUrl) {
+        if (!mediaUrl) {
+          handleMissingMediaUrl(media);
+          return;
+        }
+
+        openUrlInTab(mediaUrl);
+      });
+      return;
+    }
+
+    resolveVideoMedia(media).then(function (resolvedMedia) {
+      const mediaUrl = resolvedMedia && (resolvedMedia.videoUrl || resolvedMedia.url);
       if (!mediaUrl) {
         handleMissingMediaUrl(media);
         return;
       }
 
-      if (typeof GM_openInTab === 'function') {
-        GM_openInTab(mediaUrl, { active: true, insert: true });
-      } else {
-        window.open(mediaUrl, '_blank', 'noopener');
+      if (!hasSeparateAudio(resolvedMedia)) {
+        openUrlInTab(mediaUrl);
+        return;
       }
+
+      muxVideoMedia(resolvedMedia)
+        .then(function (blob) {
+          hideStatus();
+          openUrlInTab(URL.createObjectURL(blob));
+        })
+        .catch(function (error) {
+          const fallbackUrl = handleMuxFailure(error, resolvedMedia);
+          if (fallbackUrl) openUrlInTab(fallbackUrl);
+        });
+    }).catch(function (error) {
+      console.warn('Instagram View Image in New Tab: could not open media.', error);
+      handleMissingMediaUrl(media);
     });
   }
 
@@ -779,16 +1243,76 @@
     const media = activeMedia;
     hideMenu();
 
-    resolveActiveMediaUrl(media).then(function (mediaUrl) {
-      if (!media || !mediaUrl) {
+    if (!media || media.type !== 'video') {
+      resolveActiveMediaUrl(media).then(function (mediaUrl) {
+        if (!media || !mediaUrl) {
+          handleMissingMediaUrl(media);
+          return;
+        }
+
+        if (typeof GM_download === 'function') {
+          GM_download({
+            url: mediaUrl,
+            name: media.filename,
+            saveAs: true
+          });
+          return;
+        }
+
+        const link = document.createElement('a');
+        link.href = mediaUrl;
+        link.download = media.filename;
+        link.rel = 'noopener';
+        link.target = '_blank';
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+      });
+      return;
+    }
+
+    resolveVideoMedia(media).then(function (resolvedMedia) {
+      const mediaUrl = resolvedMedia && (resolvedMedia.videoUrl || resolvedMedia.url);
+      if (!mediaUrl) {
         handleMissingMediaUrl(media);
+        return;
+      }
+
+      if (hasSeparateAudio(resolvedMedia)) {
+        muxVideoMedia(resolvedMedia)
+          .then(function (blob) {
+            hideStatus();
+            saveBlob(blob, resolvedMedia.filename);
+          })
+          .catch(function (error) {
+            const fallbackUrl = handleMuxFailure(error, resolvedMedia);
+            if (!fallbackUrl) return;
+
+            if (typeof GM_download === 'function') {
+              GM_download({
+                url: fallbackUrl,
+                name: resolvedMedia.filename,
+                saveAs: true
+              });
+              return;
+            }
+
+            const link = document.createElement('a');
+            link.href = fallbackUrl;
+            link.download = resolvedMedia.filename;
+            link.rel = 'noopener';
+            link.target = '_blank';
+            document.body.appendChild(link);
+            link.click();
+            link.remove();
+          });
         return;
       }
 
       if (typeof GM_download === 'function') {
         GM_download({
           url: mediaUrl,
-          name: media.filename,
+          name: resolvedMedia.filename,
           saveAs: true
         });
         return;
@@ -796,12 +1320,15 @@
 
       const link = document.createElement('a');
       link.href = mediaUrl;
-      link.download = media.filename;
+      link.download = resolvedMedia.filename;
       link.rel = 'noopener';
       link.target = '_blank';
       document.body.appendChild(link);
       link.click();
       link.remove();
+    }).catch(function (error) {
+      console.warn('Instagram View Image in New Tab: could not save media.', error);
+      handleMissingMediaUrl(media);
     });
   }
 
@@ -887,6 +1414,14 @@
     return copyTextToClipboard(mediaUrl).catch(handleCopyTextFailure);
   }
 
+  function copyVideoStreamUrls(media) {
+    const text = hasSeparateAudio(media)
+      ? `Video: ${media.videoUrl}\nAudio: ${media.audioUrl}`
+      : media.videoUrl || media.url || '';
+
+    return copyTextToClipboard(text).catch(handleCopyTextFailure);
+  }
+
   function copyActiveMedia() {
     const media = activeMedia;
     hideMenu();
@@ -894,12 +1429,15 @@
     if (!media) return;
 
     if (media.type === 'video') {
-      resolveActiveMediaUrl(media).then(function (mediaUrl) {
-        if (mediaUrl) {
-          copyMediaUrlFallback(mediaUrl);
+      resolveVideoMedia(media).then(function (resolvedMedia) {
+        if (resolvedMedia && (resolvedMedia.videoUrl || resolvedMedia.url)) {
+          copyVideoStreamUrls(resolvedMedia);
         } else {
           handleMissingMediaUrl(media);
         }
+      }).catch(function (error) {
+        console.warn('Instagram View Image in New Tab: could not copy video URL.', error);
+        handleMissingMediaUrl(media);
       });
       return;
     }

--- a/Instagram/Instagram View Image in New Tab-1.0.user.js
+++ b/Instagram/Instagram View Image in New Tab-1.0.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Instagram View Image in New Tab
 // @namespace    https://github.com/brucehart/userscripts
-// @version      1.6
+// @version      1.7
 // @description  Add right-click menu items on Instagram images and videos to open, save, or copy the real media.
 // @author       Bruce J. Hart
 // @match        https://www.instagram.com/*
@@ -341,6 +341,26 @@
     return textarea.value;
   }
 
+  function escapeBareXmlAmpersands(text) {
+    return text.replace(/&(?!#\d+;|#x[0-9a-f]+;|[a-z][a-z0-9_.:-]*;)/gi, '&amp;');
+  }
+
+  function dashManifestTextCandidates(rawValue) {
+    const candidates = [];
+    const seen = new Set();
+
+    function add(value) {
+      if (typeof value !== 'string' || seen.has(value)) return;
+      seen.add(value);
+      candidates.push(value);
+    }
+
+    add(rawValue);
+    add(decodeHtmlEntities(rawValue));
+
+    return candidates;
+  }
+
   function decodeJsonString(rawValue) {
     try {
       return JSON.parse(`"${rawValue}"`);
@@ -406,14 +426,17 @@
 
   function videoDetailsFromDashManifest(rawValue) {
     for (const candidate of expandPossibleVideoStrings(rawValue)) {
-      const manifestText = decodeHtmlEntities(candidate);
-      if (!/<BaseURL\b/i.test(manifestText)) continue;
+      for (const manifestText of dashManifestTextCandidates(candidate)) {
+        if (!/<BaseURL\b/i.test(manifestText)) continue;
 
-      const doc = new DOMParser().parseFromString(manifestText, 'application/xml');
-      const details = bestDashBaseUrlsFromDocument(doc);
-      if (hasVideoDetails(details)) return details;
+        const safeManifestText = escapeBareXmlAmpersands(manifestText);
+        const doc = new DOMParser().parseFromString(safeManifestText, 'application/xml');
+        const details = bestDashBaseUrlsFromDocument(doc);
+        if (hasVideoDetails(details)) return details;
+      }
 
-      const baseUrlMatch = manifestText.match(/<BaseURL[^>]*>([\s\S]*?)<\/BaseURL>/i);
+      const fallbackText = decodeHtmlEntities(candidate);
+      const baseUrlMatch = fallbackText.match(/<BaseURL[^>]*>([\s\S]*?)<\/BaseURL>/i);
       if (!baseUrlMatch) continue;
 
       const url = normalizeAbsoluteUrl(baseUrlMatch[1]);
@@ -469,17 +492,22 @@
     state.visited.add(value);
 
     if (Array.isArray(value)) {
+      let fallbackDetails = createVideoDetails('', '');
       for (const item of value) {
         const details = findVideoDetailsInValue(item, state, depth + 1);
-        if (hasVideoDetails(details)) return details;
+        if (hasSeparateAudio(details)) return details;
+        if (hasVideoDetails(details) && !hasVideoDetails(fallbackDetails)) {
+          fallbackDetails = details;
+        }
       }
-      return createVideoDetails('', '');
+      return fallbackDetails;
     }
 
     const keys = Object.keys(value).sort(function (left, right) {
       const priorityDelta = keySearchPriority(left) - keySearchPriority(right);
       return priorityDelta || 0;
     });
+    let fallbackDetails = createVideoDetails('', '');
 
     for (const key of keys) {
       let nestedValue;
@@ -498,10 +526,13 @@
       }
 
       const details = findVideoDetailsInValue(nestedValue, state, depth + 1);
-      if (hasVideoDetails(details)) return details;
+      if (hasSeparateAudio(details)) return details;
+      if (hasVideoDetails(details) && !hasVideoDetails(fallbackDetails)) {
+        fallbackDetails = details;
+      }
     }
 
-    return createVideoDetails('', '');
+    return fallbackDetails;
   }
 
   function findVideoDetailsInElementData(element) {

--- a/Instagram/Instagram View Image in New Tab-1.0.user.js
+++ b/Instagram/Instagram View Image in New Tab-1.0.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Instagram View Image in New Tab
 // @namespace    https://github.com/brucehart/userscripts
-// @version      1.7
+// @version      1.8
 // @description  Add right-click menu items on Instagram images and videos to open, save, or copy the real media.
 // @author       Bruce J. Hart
 // @match        https://www.instagram.com/*
@@ -26,9 +26,9 @@
   const INSTAGRAM_MEDIA_LINK_SELECTOR = 'a[href^="/p/"], a[href^="/reel/"], a[href^="/reels/"], a[href^="/tv/"]';
   const DASH_MANIFEST_KEY_PATTERN = /dash_manifest/i;
   const VIDEO_URL_KEY_PATTERN = /^(?:video_url|playable_url|playable_url_quality_hd|dash_manifest|video_dash_manifest|contentUrl|src|url)$/i;
-  const MAX_OBJECT_SEARCH_DEPTH = 8;
-  const MAX_OBJECT_SEARCH_NODES = 2500;
-  const FFMPEG_CORE_URL = 'https://unpkg.com/@ffmpeg/core@0.11.0/dist/ffmpeg-core.js';
+  const MAX_OBJECT_SEARCH_DEPTH = 12;
+  const MAX_OBJECT_SEARCH_NODES = 8000;
+  const FFMPEG_CORE_URL = 'https://unpkg.com/@ffmpeg/core-st@0.11.1/dist/ffmpeg-core.js';
   let activeMedia = null;
   let menu = null;
   let statusBox = null;
@@ -129,6 +129,50 @@
 
   function videoDetailsFromUrl(url) {
     return createVideoDetails(url, '');
+  }
+
+  function mediaUrlFingerprint(url) {
+    const normalizedUrl = normalizeAbsoluteUrl(url) || normalizeUrl(url);
+    if (!normalizedUrl) return '';
+
+    try {
+      const parsed = new URL(normalizedUrl);
+      return decodeURIComponent(parsed.pathname)
+        .toLowerCase()
+        .replace(/\/+$/g, '');
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function sameMediaUrl(leftUrl, rightUrl) {
+    const leftFingerprint = mediaUrlFingerprint(leftUrl);
+    const rightFingerprint = mediaUrlFingerprint(rightUrl);
+    return Boolean(leftFingerprint && rightFingerprint && leftFingerprint === rightFingerprint);
+  }
+
+  function selectVideoDetails(candidates, preferredVideoUrl, requirePreferredMatch) {
+    const seen = new Set();
+    const uniqueCandidates = candidates.filter(function (details) {
+      if (!hasVideoDetails(details)) return false;
+
+      const key = `${details.videoUrl}\n${details.audioUrl || ''}`;
+      if (seen.has(key)) return false;
+      seen.add(key);
+      return true;
+    });
+
+    if (preferredVideoUrl) {
+      const matchingCandidates = uniqueCandidates.filter(function (details) {
+        return sameMediaUrl(details.videoUrl, preferredVideoUrl);
+      });
+      const matchingSeparateAudio = matchingCandidates.find(hasSeparateAudio);
+      if (matchingSeparateAudio) return matchingSeparateAudio;
+      if (matchingCandidates[0]) return matchingCandidates[0];
+      if (requirePreferredMatch) return createVideoDetails('', '');
+    }
+
+    return uniqueCandidates.find(hasSeparateAudio) || uniqueCandidates[0] || createVideoDetails('', '');
   }
 
   function keySearchPriority(key) {
@@ -479,35 +523,31 @@
     return '';
   }
 
-  function findVideoDetailsInValue(value, state, depth) {
-    if (!value || state.nodes > MAX_OBJECT_SEARCH_NODES || depth > MAX_OBJECT_SEARCH_DEPTH) {
-      return createVideoDetails('', '');
-    }
+  function collectVideoDetailsInValue(value, state, depth, candidates) {
+    if (!value || state.nodes > MAX_OBJECT_SEARCH_NODES || depth > MAX_OBJECT_SEARCH_DEPTH) return;
     state.nodes += 1;
 
-    if (typeof value === 'string') return normalizePotentialVideoDetails(value);
-    if (typeof value !== 'object' && typeof value !== 'function') return createVideoDetails('', '');
-    if (state.visited.has(value)) return createVideoDetails('', '');
+    if (typeof value === 'string') {
+      const details = normalizePotentialVideoDetails(value);
+      if (hasVideoDetails(details)) candidates.push(details);
+      return;
+    }
+    if (typeof value !== 'object' && typeof value !== 'function') return;
+    if (state.visited.has(value)) return;
 
     state.visited.add(value);
 
     if (Array.isArray(value)) {
-      let fallbackDetails = createVideoDetails('', '');
       for (const item of value) {
-        const details = findVideoDetailsInValue(item, state, depth + 1);
-        if (hasSeparateAudio(details)) return details;
-        if (hasVideoDetails(details) && !hasVideoDetails(fallbackDetails)) {
-          fallbackDetails = details;
-        }
+        collectVideoDetailsInValue(item, state, depth + 1, candidates);
       }
-      return fallbackDetails;
+      return;
     }
 
     const keys = Object.keys(value).sort(function (left, right) {
       const priorityDelta = keySearchPriority(left) - keySearchPriority(right);
       return priorityDelta || 0;
     });
-    let fallbackDetails = createVideoDetails('', '');
 
     for (const key of keys) {
       let nestedValue;
@@ -525,40 +565,16 @@
         continue;
       }
 
-      const details = findVideoDetailsInValue(nestedValue, state, depth + 1);
-      if (hasSeparateAudio(details)) return details;
-      if (hasVideoDetails(details) && !hasVideoDetails(fallbackDetails)) {
-        fallbackDetails = details;
-      }
+      collectVideoDetailsInValue(nestedValue, state, depth + 1, candidates);
     }
-
-    return fallbackDetails;
   }
 
-  function findVideoDetailsInElementData(element) {
+  function videoDetailsFromAttachedPageData(startElement, preferredVideoUrl) {
     const state = {
       visited: new WeakSet(),
       nodes: 0
     };
-
-    for (const key of Object.keys(element)) {
-      if (!/react|fiber|props|inst|internal/i.test(key)) continue;
-
-      let value;
-      try {
-        value = element[key];
-      } catch (e) {
-        continue;
-      }
-
-      const details = findVideoDetailsInValue(value, state, 0);
-      if (hasVideoDetails(details)) return details;
-    }
-
-    return createVideoDetails('', '');
-  }
-
-  function videoDetailsFromAttachedPageData(startElement) {
+    const candidates = [];
     const elements = [];
     let element = startElement;
     let depth = 0;
@@ -570,28 +586,39 @@
     }
 
     for (const candidate of elements) {
-      const details = findVideoDetailsInElementData(candidate);
-      if (hasVideoDetails(details)) return details;
+      for (const key of Object.keys(candidate)) {
+        if (!/react|fiber|props|inst|internal/i.test(key)) continue;
+
+        let value;
+        try {
+          value = candidate[key];
+        } catch (e) {
+          continue;
+        }
+
+        collectVideoDetailsInValue(value, state, 0, candidates);
+      }
     }
 
-    return createVideoDetails('', '');
+    return selectVideoDetails(candidates, preferredVideoUrl, false);
   }
 
-  function videoDetailsFromPerformanceEntries() {
+  function videoDetailsFromPerformanceEntries(preferredVideoUrl, requirePreferredMatch) {
     if (!window.performance || typeof window.performance.getEntriesByType !== 'function') {
       return createVideoDetails('', '');
     }
 
     const entries = window.performance.getEntriesByType('resource').slice().reverse();
+    const candidates = [];
     for (const entry of entries) {
       const url = normalizePotentialVideoUrl(entry.name);
-      if (url) return videoDetailsFromUrl(url);
+      if (url) candidates.push(videoDetailsFromUrl(url));
     }
 
-    return createVideoDetails('', '');
+    return selectVideoDetails(candidates, preferredVideoUrl, requirePreferredMatch);
   }
 
-  function videoDetailsFromPageGlobals() {
+  function videoDetailsFromPageGlobals(preferredVideoUrl, requirePreferredMatch) {
     const pageWindow = typeof unsafeWindow === 'undefined' ? window : unsafeWindow;
     const globalNames = [
       '_sharedData',
@@ -604,6 +631,7 @@
       visited: new WeakSet(),
       nodes: 0
     };
+    const candidates = [];
 
     for (const name of globalNames) {
       let value;
@@ -613,25 +641,25 @@
         continue;
       }
 
-      const details = findVideoDetailsInValue(value, state, 0);
-      if (hasVideoDetails(details)) return details;
+      collectVideoDetailsInValue(value, state, 0, candidates);
     }
 
-    return createVideoDetails('', '');
+    return selectVideoDetails(candidates, preferredVideoUrl, requirePreferredMatch);
   }
 
-  function videoDetailsFromDocumentScripts() {
+  function videoDetailsFromDocumentScripts(preferredVideoUrl, requirePreferredMatch) {
     const scripts = [...document.scripts].slice().reverse();
+    const candidates = [];
     for (const script of scripts) {
-      const details = extractVideoDetailsFromHtml(script.textContent || '');
-      if (hasVideoDetails(details)) return details;
+      candidates.push(...extractVideoDetailsCandidatesFromHtml(script.textContent || ''));
     }
 
-    return createVideoDetails('', '');
+    return selectVideoDetails(candidates, preferredVideoUrl, requirePreferredMatch);
   }
 
-  function extractVideoDetailsFromHtml(html) {
+  function extractVideoDetailsCandidatesFromHtml(html) {
     const decodedHtml = decodeHtmlEntities(html);
+    const candidates = [];
     const patterns = [
       /"dash_manifest"\s*:\s*"((?:\\.|[^"\\])+)"/,
       /"video_dash_manifest"\s*:\s*"((?:\\.|[^"\\])+)"/,
@@ -646,7 +674,7 @@
       if (!match) continue;
 
       const details = normalizePotentialVideoDetails(decodeJsonString(match[1]));
-      if (hasVideoDetails(details)) return details;
+      if (hasVideoDetails(details)) candidates.push(details);
     }
 
     const doc = new DOMParser().parseFromString(decodedHtml, 'text/html');
@@ -657,9 +685,17 @@
       'meta[name="twitter:player:stream"]'
     ].join(','));
     const metaUrl = metaVideo ? normalizePotentialVideoUrl(metaVideo.getAttribute('content')) : '';
-    if (metaUrl) return videoDetailsFromUrl(metaUrl);
+    if (metaUrl) candidates.push(videoDetailsFromUrl(metaUrl));
 
-    return createVideoDetails('', '');
+    return candidates;
+  }
+
+  function extractVideoDetailsFromHtml(html, preferredVideoUrl, requirePreferredMatch) {
+    return selectVideoDetails(
+      extractVideoDetailsCandidatesFromHtml(html),
+      preferredVideoUrl,
+      requirePreferredMatch
+    );
   }
 
   function getText(url) {
@@ -709,6 +745,9 @@
     if (!media) return Promise.resolve(null);
     if (media.needsMuxing && media.videoUrl && media.audioUrl) return Promise.resolve(media);
 
+    const preferredDetails = directVideoDetailsFromMedia(media);
+    const preferredVideoUrl = preferredDetails.videoUrl || '';
+    const requirePreferredMatch = Boolean(preferredVideoUrl);
     let fallbackDetails = createVideoDetails('', '');
     function rememberFallback(details) {
       if (hasVideoDetails(details) && !hasVideoDetails(fallbackDetails)) {
@@ -718,36 +757,33 @@
     }
 
     if (media.videoElement) {
-      const attachedDetails = videoDetailsFromAttachedPageData(media.videoElement);
+      const attachedDetails = videoDetailsFromAttachedPageData(media.videoElement, preferredVideoUrl);
       if (rememberFallback(attachedDetails)) {
         return Promise.resolve(applyVideoDetailsToMedia(media, attachedDetails));
       }
-    }
-
-    const globalDetails = videoDetailsFromPageGlobals();
-    if (rememberFallback(globalDetails)) {
-      return Promise.resolve(applyVideoDetailsToMedia(media, globalDetails));
-    }
-
-    const scriptDetails = videoDetailsFromDocumentScripts();
-    if (rememberFallback(scriptDetails)) {
-      return Promise.resolve(applyVideoDetailsToMedia(media, scriptDetails));
     }
 
     if (media.pageUrl) {
       if (media.resolvedMediaPromise) return media.resolvedMediaPromise;
 
       media.resolvedMediaPromise = getText(media.pageUrl)
-        .then(extractVideoDetailsFromHtml)
+        .then(function (html) {
+          return extractVideoDetailsFromHtml(html, preferredVideoUrl, requirePreferredMatch);
+        })
         .then(function (details) {
           if (hasVideoDetails(details)) return applyVideoDetailsToMedia(media, details);
 
           if (hasVideoDetails(fallbackDetails)) return applyVideoDetailsToMedia(media, fallbackDetails);
 
-          const directDetails = directVideoDetailsFromMedia(media);
-          if (hasVideoDetails(directDetails)) return applyVideoDetailsToMedia(media, directDetails);
+          if (hasVideoDetails(preferredDetails)) return applyVideoDetailsToMedia(media, preferredDetails);
 
-          const performanceDetails = videoDetailsFromPerformanceEntries();
+          const scriptDetails = videoDetailsFromDocumentScripts(preferredVideoUrl, requirePreferredMatch);
+          if (hasVideoDetails(scriptDetails)) return applyVideoDetailsToMedia(media, scriptDetails);
+
+          const globalDetails = videoDetailsFromPageGlobals(preferredVideoUrl, requirePreferredMatch);
+          if (hasVideoDetails(globalDetails)) return applyVideoDetailsToMedia(media, globalDetails);
+
+          const performanceDetails = videoDetailsFromPerformanceEntries(preferredVideoUrl, requirePreferredMatch);
           if (hasVideoDetails(performanceDetails)) return applyVideoDetailsToMedia(media, performanceDetails);
 
           return media;
@@ -757,10 +793,15 @@
 
           if (hasVideoDetails(fallbackDetails)) return applyVideoDetailsToMedia(media, fallbackDetails);
 
-          const directDetails = directVideoDetailsFromMedia(media);
-          if (hasVideoDetails(directDetails)) return applyVideoDetailsToMedia(media, directDetails);
+          if (hasVideoDetails(preferredDetails)) return applyVideoDetailsToMedia(media, preferredDetails);
 
-          const performanceDetails = videoDetailsFromPerformanceEntries();
+          const scriptDetails = videoDetailsFromDocumentScripts(preferredVideoUrl, requirePreferredMatch);
+          if (hasVideoDetails(scriptDetails)) return applyVideoDetailsToMedia(media, scriptDetails);
+
+          const globalDetails = videoDetailsFromPageGlobals(preferredVideoUrl, requirePreferredMatch);
+          if (hasVideoDetails(globalDetails)) return applyVideoDetailsToMedia(media, globalDetails);
+
+          const performanceDetails = videoDetailsFromPerformanceEntries(preferredVideoUrl, requirePreferredMatch);
           if (hasVideoDetails(performanceDetails)) return applyVideoDetailsToMedia(media, performanceDetails);
 
           return media;
@@ -773,12 +814,21 @@
       return Promise.resolve(applyVideoDetailsToMedia(media, fallbackDetails));
     }
 
-    const directDetails = directVideoDetailsFromMedia(media);
-    if (hasVideoDetails(directDetails)) {
-      return Promise.resolve(applyVideoDetailsToMedia(media, directDetails));
+    if (hasVideoDetails(preferredDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, preferredDetails));
     }
 
-    const performanceDetails = videoDetailsFromPerformanceEntries();
+    const scriptDetails = videoDetailsFromDocumentScripts(preferredVideoUrl, requirePreferredMatch);
+    if (hasVideoDetails(scriptDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, scriptDetails));
+    }
+
+    const globalDetails = videoDetailsFromPageGlobals(preferredVideoUrl, requirePreferredMatch);
+    if (hasVideoDetails(globalDetails)) {
+      return Promise.resolve(applyVideoDetailsToMedia(media, globalDetails));
+    }
+
+    const performanceDetails = videoDetailsFromPerformanceEntries(preferredVideoUrl, requirePreferredMatch);
     if (hasVideoDetails(performanceDetails)) {
       return Promise.resolve(applyVideoDetailsToMedia(media, performanceDetails));
     }

--- a/Instagram/Instagram View Image in New Tab-1.0.user.js
+++ b/Instagram/Instagram View Image in New Tab-1.0.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Instagram View Image in New Tab
 // @namespace    https://github.com/brucehart/userscripts
-// @version      1.9
+// @version      1.10
 // @description  Add right-click menu items on Instagram images and videos to open, save, or copy the real media.
 // @author       Bruce J. Hart
 // @match        https://www.instagram.com/*
@@ -1132,6 +1132,104 @@
     }
   }
 
+  function escapeHtml(text) {
+    return String(text || '')
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;');
+  }
+
+  function openSeparateStreamsInTab(media) {
+    const pageData = JSON.stringify({
+      title: media.filename || 'Instagram video',
+      videoUrl: media.videoUrl,
+      audioUrl: media.audioUrl
+    }).replace(/</g, '\\u003c');
+    const title = escapeHtml(media.filename || 'Instagram video');
+    const html = `<!doctype html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>${title}</title>
+<style>
+  html, body { margin: 0; min-height: 100%; background: #111; color: #f5f5f5; font: 14px/1.4 system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif; }
+  body { display: grid; grid-template-rows: 1fr auto; }
+  main { min-height: 0; display: grid; place-items: center; }
+  video { display: block; max-width: 100vw; max-height: calc(100vh - 44px); background: #000; }
+  footer { min-height: 44px; box-sizing: border-box; padding: 10px 14px; color: rgba(255,255,255,.72); }
+</style>
+</head>
+<body>
+<main><video id="video" controls autoplay playsinline></video></main>
+<audio id="audio" preload="auto"></audio>
+<footer id="message">Audio is synced from Instagram's separate audio stream.</footer>
+<script>
+  const media = ${pageData};
+  const video = document.getElementById('video');
+  const audio = document.getElementById('audio');
+  const message = document.getElementById('message');
+  let syncing = false;
+
+  document.title = media.title;
+  video.src = media.videoUrl;
+  audio.src = media.audioUrl;
+
+  function setMessage(text) {
+    message.textContent = text;
+  }
+
+  function syncAudio(force) {
+    if (!Number.isFinite(video.currentTime)) return;
+    const drift = Math.abs((audio.currentTime || 0) - video.currentTime);
+    if (force || drift > 0.25) {
+      syncing = true;
+      try {
+        audio.currentTime = video.currentTime;
+      } finally {
+        syncing = false;
+      }
+    }
+  }
+
+  video.addEventListener('play', function () {
+    syncAudio(true);
+    audio.playbackRate = video.playbackRate;
+    audio.volume = video.volume;
+    audio.muted = video.muted;
+    audio.play().then(function () {
+      setMessage('Audio is synced from Instagram\\'s separate audio stream.');
+    }).catch(function () {
+      setMessage('Press play again if the browser blocked the separate audio stream.');
+    });
+  });
+  video.addEventListener('pause', function () { audio.pause(); });
+  video.addEventListener('ended', function () { audio.pause(); });
+  video.addEventListener('seeking', function () { syncAudio(true); });
+  video.addEventListener('seeked', function () { syncAudio(true); });
+  video.addEventListener('ratechange', function () { audio.playbackRate = video.playbackRate; });
+  video.addEventListener('volumechange', function () {
+    audio.volume = video.volume;
+    audio.muted = video.muted;
+  });
+  video.addEventListener('timeupdate', function () {
+    if (!syncing && !video.paused) syncAudio(false);
+  });
+  audio.addEventListener('error', function () {
+    setMessage('The separate audio stream could not be loaded.');
+  });
+</script>
+</body>
+</html>`;
+    const objectUrl = URL.createObjectURL(new Blob([html], { type: 'text/html' }));
+    const openedWindow = window.open(objectUrl, '_blank', 'noopener');
+    if (!openedWindow) openUrlInTab(media.videoUrl);
+    window.setTimeout(function () {
+      URL.revokeObjectURL(objectUrl);
+    }, 120000);
+  }
+
   function saveBlob(blob, filename) {
     const objectUrl = URL.createObjectURL(blob);
     const link = document.createElement('a');
@@ -1343,15 +1441,7 @@
         return;
       }
 
-      muxVideoMedia(resolvedMedia)
-        .then(function (blob) {
-          hideStatus();
-          openUrlInTab(URL.createObjectURL(blob));
-        })
-        .catch(function (error) {
-          const fallbackUrl = handleMuxFailure(error, resolvedMedia);
-          if (fallbackUrl) openUrlInTab(fallbackUrl);
-        });
+      openSeparateStreamsInTab(resolvedMedia);
     }).catch(function (error) {
       console.warn('Instagram View Image in New Tab: could not open media.', error);
       handleMissingMediaUrl(media);

--- a/Instagram/Instagram View Image in New Tab-1.0.user.js
+++ b/Instagram/Instagram View Image in New Tab-1.0.user.js
@@ -1,13 +1,14 @@
 // ==UserScript==
 // @name         Instagram View Image in New Tab
 // @namespace    https://github.com/brucehart/userscripts
-// @version      1.8
+// @version      1.9
 // @description  Add right-click menu items on Instagram images and videos to open, save, or copy the real media.
 // @author       Bruce J. Hart
 // @match        https://www.instagram.com/*
 // @match        https://instagram.com/*
 // @run-at       document-idle
 // @require      https://unpkg.com/@ffmpeg/ffmpeg@0.11.6/dist/ffmpeg.min.js
+// @require      https://unpkg.com/@ffmpeg/core-st@0.11.1/dist/ffmpeg-core.js
 // @grant        GM_openInTab
 // @grant        GM_download
 // @grant        GM_setClipboard
@@ -35,6 +36,7 @@
   let ffmpegInstance = null;
   let ffmpegLoadPromise = null;
   let muxQueue = Promise.resolve();
+  let lastFfmpegLogMessage = '';
 
   function normalizeUrl(rawUrl) {
     if (!rawUrl) return '';
@@ -145,7 +147,37 @@
     }
   }
 
+  function decodeBase64Text(rawValue) {
+    if (!rawValue) return '';
+    try {
+      const base64 = rawValue.replace(/-/g, '+').replace(/_/g, '/');
+      const paddedBase64 = base64.padEnd(Math.ceil(base64.length / 4) * 4, '=');
+      return atob(paddedBase64);
+    } catch (e) {
+      return '';
+    }
+  }
+
+  function mediaAssetId(url) {
+    const normalizedUrl = normalizeAbsoluteUrl(url) || normalizeUrl(url);
+    if (!normalizedUrl) return '';
+
+    try {
+      const parsed = new URL(normalizedUrl);
+      const encodedMetadata = parsed.searchParams.get('efg');
+      const metadataText = decodeBase64Text(encodedMetadata);
+      const match = metadataText.match(/"(?:xpv_asset_id|asset_id|video_id)"\s*:\s*(?:"([^"]+)"|([0-9]+))/);
+      return match ? match[1] || match[2] || '' : '';
+    } catch (e) {
+      return '';
+    }
+  }
+
   function sameMediaUrl(leftUrl, rightUrl) {
+    const leftAssetId = mediaAssetId(leftUrl);
+    const rightAssetId = mediaAssetId(rightUrl);
+    if (leftAssetId && rightAssetId) return leftAssetId === rightAssetId;
+
     const leftFingerprint = mediaUrlFingerprint(leftUrl);
     const rightFingerprint = mediaUrlFingerprint(rightUrl);
     return Boolean(leftFingerprint && rightFingerprint && leftFingerprint === rightFingerprint);
@@ -600,7 +632,7 @@
       }
     }
 
-    return selectVideoDetails(candidates, preferredVideoUrl, false);
+    return selectVideoDetails(candidates, preferredVideoUrl, Boolean(preferredVideoUrl));
   }
 
   function videoDetailsFromPerformanceEntries(preferredVideoUrl, requirePreferredMatch) {
@@ -1134,6 +1166,9 @@
           showStatus('Merging video and audio...', percent);
         }
       });
+      ffmpegInstance.setLogger(function (event) {
+        if (event && event.message) lastFfmpegLogMessage = event.message;
+      });
     }
 
     if (ffmpegInstance.isLoaded()) return Promise.resolve(ffmpegInstance);
@@ -1198,6 +1233,7 @@
       return Promise.reject(new Error('Missing separate video or audio stream'));
     }
 
+    lastFfmpegLogMessage = '';
     const id = `${Date.now()}-${Math.floor(Math.random() * 1000000)}`;
     const videoInput = `instagram-video-${id}.mp4`;
     const audioInput = `instagram-audio-${id}.m4a`;
@@ -1228,7 +1264,6 @@
           '-map', '1:a:0',
           '-c', 'copy',
           '-shortest',
-          '-movflags', '+faststart',
           output
         ).then(function () {
           const mergedBytes = ffmpeg.FS('readFile', output);
@@ -1255,12 +1290,15 @@
     console.warn('Instagram View Image in New Tab: could not merge video and audio.', error);
     hideStatus();
 
+    const detail = lastFfmpegLogMessage || (error && error.message) || String(error || '');
+    const detailSuffix = detail ? `\n\nLast merge error: ${detail}` : '';
+
     if (media && media.videoUrl) {
-      window.alert('Found separate Instagram video and audio streams, but could not merge them in this browser. Falling back to the video-only stream.');
+      window.alert(`Found separate Instagram video and audio streams, but could not merge them in this browser. Falling back to the video-only stream.${detailSuffix}`);
       return media.videoUrl;
     }
 
-    window.alert('Found separate Instagram video and audio streams, but could not merge them in this browser.');
+    window.alert(`Found separate Instagram video and audio streams, but could not merge them in this browser.${detailSuffix}`);
     return '';
   }
 

--- a/Instagram/README.md
+++ b/Instagram/README.md
@@ -15,6 +15,8 @@ Adds a custom right-click menu on Instagram images and videos with actions to:
 
 The script checks video elements first, then normal image elements, including `srcset` for the largest available image, and finally falls back to CSS `background-image` URLs on nearby elements. Images are copied as image data when the browser supports it, with a URL fallback. Videos are copied as their direct video URL. If Instagram only exposes a temporary `blob:` playback URL, the script tries to resolve the real video URL from page data, loaded resource URLs, or the surrounding post or reel page before opening, saving, or copying it.
 
+Some Instagram videos expose separate DASH video and audio streams. When both streams are found, **View Video in New Tab** and **Save Video** download both streams and merge them in the browser with a pinned `ffmpeg.wasm` dependency loaded from unpkg. The first merge can take a moment while FFmpeg loads, and long videos may take longer. **Copy Video URL** copies both source stream URLs when the audio is separate because the merged `blob:` URL only works in the current browser session.
+
 ## Installation
 
 1. Install the Tampermonkey extension in your browser.


### PR DESCRIPTION
## Summary
- Adds in-browser audio/video muxing for Instagram videos where audio is exposed as a separate DASH stream.

## Changes
- Parses DASH manifests for best video and audio representations instead of only using the first video URL.
- Loads pinned ffmpeg.wasm dependencies lazily and merges separate streams for open/save actions.
- Updates copy behavior and README notes for separate audio/video streams.

## Testing
- `node --check Instagram/Instagram View Image in New Tab-1.0.user.js`
- `git diff --check`
- Manual Tampermonkey/Instagram verification was not run in this environment.
